### PR TITLE
Float Literals Hotfix

### DIFF
--- a/Source/AtlusScriptLibrary/FlowScriptLanguage/Compiler/Parser/CompilationUnitParser.cs
+++ b/Source/AtlusScriptLibrary/FlowScriptLanguage/Compiler/Parser/CompilationUnitParser.cs
@@ -1495,7 +1495,7 @@ namespace AtlusScriptLibrary.FlowScriptLanguage.Compiler.Parser
                 floatString = floatString.Substring( 0, floatString.Length - 1 );
             }
 
-            if ( !float.TryParse( floatString, out float value ) )
+            if ( !float.TryParse( floatString, NumberStyles.Float, CultureInfo.InvariantCulture, out float value ) )
             {
                 LogError( node.Symbol, "Invalid float value" );
                 return false;

--- a/Source/AtlusScriptLibrary/FlowScriptLanguage/Decompiler/CompilationUnitWriter.cs
+++ b/Source/AtlusScriptLibrary/FlowScriptLanguage/Decompiler/CompilationUnitWriter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -776,7 +775,7 @@ namespace AtlusScriptLibrary.FlowScriptLanguage.Decompiler
             // Float literal
             private void WriteFloatLiteral( FloatLiteral floatLiteral )
             {
-                Write($"{floatLiteral.Value.ToString("0.00#####", CultureInfo.InvariantCulture)}f");
+                Write( $"{floatLiteral}f" );
             }
 
             // String literal

--- a/Source/AtlusScriptLibrary/FlowScriptLanguage/Decompiler/CompilationUnitWriter.cs
+++ b/Source/AtlusScriptLibrary/FlowScriptLanguage/Decompiler/CompilationUnitWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -775,7 +776,7 @@ namespace AtlusScriptLibrary.FlowScriptLanguage.Decompiler
             // Float literal
             private void WriteFloatLiteral( FloatLiteral floatLiteral )
             {
-                Write( $"{floatLiteral}f" );
+                Write($"{floatLiteral.Value.ToString("0.00#####", CultureInfo.InvariantCulture)}f");
             }
 
             // String literal

--- a/Source/AtlusScriptLibrary/FlowScriptLanguage/Syntax/Statements/Expressions/Literals/FloatLiteral.cs
+++ b/Source/AtlusScriptLibrary/FlowScriptLanguage/Syntax/Statements/Expressions/Literals/FloatLiteral.cs
@@ -12,6 +12,11 @@ namespace AtlusScriptLibrary.FlowScriptLanguage.Syntax
         {
         }
 
+        public override string ToString()
+        {
+            return FormattableString.Invariant($"{Value:0.00#####}");
+        }
+
         public bool Equals( FloatLiteral other )
         {
             return Value == other?.Value;


### PR DESCRIPTION
Changes the compiler/decompiler to parse/write float literals with `InvariantCulture`.

Should prevent issues with users who have `,` set as a decimal separator (as in the `de`, `es-AR` UI cultures).